### PR TITLE
Update gulpfile.js to work with Gulp 4

### DIFF
--- a/autoprefixer/gulpfile.js
+++ b/autoprefixer/gulpfile.js
@@ -1,14 +1,13 @@
 var gulp = require('gulp');
 var autoprefixer = require('gulp-autoprefixer');
 
-
-gulp.task('styles',function() {
+gulp.task('styles', done => {
   gulp.src('css/styles.css')
     .pipe(autoprefixer())
     .pipe(gulp.dest('build'))
+    done();
 });
 
-
 gulp.task('watch',function() {
-  gulp.watch('css/styles.css', ['styles']);
+  gulp.watch('css/styles.css', gulp.series('styles'));
 });


### PR DESCRIPTION
Hope this fix saves people some headaches.

Gulp 4 has broken the gulpfile.js this Change will Update gulpfile.js to work with Gulp 4.

for more info on the fix:
https://stackoverflow.com/questions/36897877/gulp-error-the-following-tasks-did-not-complete-did-you-forget-to-signal-async
https://stackoverflow.com/questions/39665773/gulp-error-watch-task-has-to-be-a-function